### PR TITLE
Update to handle wizards module

### DIFF
--- a/src/main/webapp/components/app-root/content.tsx
+++ b/src/main/webapp/components/app-root/content.tsx
@@ -7,6 +7,17 @@ import { useAppRootContext } from '../app-root/app-root.pure'
 import { Route, Switch } from 'react-router-dom'
 import { InstanceRouteContextProvider } from './route'
 import { Iframe } from '../iframe/iframe'
+import { ID_TO_NAME } from './links'
+
+const Wizards = () => {
+  const { modules } = useAppRootContext()
+  const wizardsModule = modules.filter(module => module.id === 'setup')[0]
+  if (wizardsModule === undefined) {
+    return <div>Docs not yet available</div>
+  }
+  const srcUrl = wizardsModule.iframeLocation
+  return <Iframe url={srcUrl} />
+}
 
 const Docs = () => {
   const { modules } = useAppRootContext()
@@ -58,10 +69,11 @@ export const Content = () => {
         render={routeProps => {
           const currentModule = modules.filter(
             module =>
-              module.name.toLowerCase() === routeProps.match.params.moduleId
+              ID_TO_NAME[module.id].toLowerCase() ===
+              routeProps.match.params.moduleId
           )[0]
           if (currentModule !== undefined) {
-            switch (currentModule.name) {
+            switch (ID_TO_NAME[currentModule.id]) {
               case 'System':
                 return (
                   <InstanceRouteContextProvider>
@@ -76,12 +88,14 @@ export const Content = () => {
                 )
               case 'Documentation':
                 return <Docs />
-              case 'Setup':
+              case 'Installer':
                 return (
                   <InstanceRouteContextProvider>
                     <Installer />
                   </InstanceRouteContextProvider>
                 )
+              case 'Wizards':
+                return <Wizards />
             }
           }
           return <NoMatch />

--- a/src/main/webapp/components/app-root/links.tsx
+++ b/src/main/webapp/components/app-root/links.tsx
@@ -7,6 +7,7 @@ import {
   InfoIcon,
   InstallerIcon,
   AppsIcon,
+  CardModeIcon,
 } from '@connexta/atlas/atoms/icons'
 import {
   List,
@@ -15,11 +16,20 @@ import {
   ListItemText,
 } from '@connexta/atlas/atoms/list'
 
-const NAME_TO_ICON = {
-  Applications: AppsIcon,
-  Documentation: BookIcon,
-  Setup: InstallerIcon,
-  System: InfoIcon,
+const ID_TO_ICON = {
+  applications: AppsIcon,
+  docs: BookIcon,
+  installation: InstallerIcon,
+  configurations: InfoIcon,
+  setup: CardModeIcon,
+} as { [key: string]: any }
+
+export const ID_TO_NAME = {
+  applications: 'Applications',
+  docs: 'Documentation',
+  installation: 'Installer',
+  configurations: 'System',
+  setup: 'Wizards',
 } as { [key: string]: any }
 
 export const Links = () => {
@@ -30,15 +40,15 @@ export const Links = () => {
     <>
       <List>
         {modules.map(module => {
-          const Icon = NAME_TO_ICON[module.name] as any
-          const url = `/admin/${module.name.toLowerCase()}`
+          const Icon = ID_TO_ICON[module.id] as any
+          const url = `/admin/${ID_TO_NAME[module.id].toLowerCase()}`
           const isCurrentUrl = location.pathname.indexOf(url) !== -1
 
           return (
             <Link to={url} key={url}>
               <ListItem button selected={isCurrentUrl} tabIndex={-1}>
                 <ListItemIcon>{Icon ? <Icon /> : <></>}</ListItemIcon>
-                <ListItemText primary={module.name} />
+                <ListItemText primary={ID_TO_NAME[module.id]} />
               </ListItem>
             </Link>
           )


### PR DESCRIPTION
 - Wizards module and installer module use the same name, so switched things over to use id.  At one point we should update the module information sent from the backend to better match what we display in the UIs.  Right now we do a lot of coercing.