### PR TITLE
Marks uncompiled source as private

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "https://github.com/connexta/kanri.git"
   },
+  "private": true,
   "engines": {
     "node": ">=0.10.5"
   },
@@ -33,6 +34,7 @@
     "chokidar": "3.0.2",
     "cpx": "1.5.0",
     "express": "4.17.1",
+    "json": "9.0.6",
     "lodash.debounce": "4.0.8",
     "notistack": "0.9.11",
     "querystring": "0.2.0",
@@ -74,7 +76,7 @@
     "yup": "0.27.0"
   },
   "scripts": {
-    "copy:package": "cpx package.json dist && cpx \"src/**/!(*.tsx)\" \"dist/src\"",
+    "copy:package": "cpx package.json dist && json -I -f dist/package.json -e 'this.private=false' && cpx \"src/**/!(*.tsx)\" \"dist/src\"",
     "start": "ace start",
     "start:capture": "ace start --env capture & yarn capture:mocks",
     "start:mocks": "ace start --env mocks",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8771,6 +8771,11 @@ json5@^2.1.0, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+json@9.0.6:
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/json/-/json-9.0.6.tgz#7972c2a5a48a42678db2730c7c2c4ee6e4e24585"
+  integrity sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=
+
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"


### PR DESCRIPTION
 - Adds json editing dep to flip the boolean for the dist.  This should help prevent unintended release of the uncompiled source.